### PR TITLE
Login retouch

### DIFF
--- a/handpickt/src/components/Login/Login.js
+++ b/handpickt/src/components/Login/Login.js
@@ -69,15 +69,15 @@ const Login = (props) => {
 
                 //Authenticate the User entry//
         const authenticateUser = (foundUser) => {
-            if (loginForm.userName === foundUser.userName && loginForm.password === foundUser.passwords[0].password) {
-                delete foundUser.passwords
+            if (loginForm.userName === foundUser.userName && loginForm.password === foundUser.password) {
+                delete foundUser.password
                 sessionStorage.setItem("credentials", JSON.stringify(foundUser))
                 props.history.push("/dashboard")
             }
             else if (loginForm.userName !== foundUser.userName) {
                 toggleBadAccount()
             }
-            else if (loginForm.password !== foundUser.passwords[0].password) {
+            else if (loginForm.password !== foundUser.password) {
                 toggleBadPassword()
             }
         }

--- a/handpickt/src/components/Registration/Registration.js
+++ b/handpickt/src/components/Registration/Registration.js
@@ -110,8 +110,9 @@ const Registration = (props) => {
                                     constructNewUserObject()
                                     }
                                 }) 
-            })
-}
+                            })
+                        }       
+    }
         //Make the new user object to send to the database
     const constructNewUserObject = () => {
         let newUserObject = {
@@ -120,36 +121,25 @@ const Registration = (props) => {
             image: registrationForm.image
         }
        API.addNew( newUserObject, "users" )
-       .then(() => attachUserIdAndSavePassword())
+       .then(() => placeNewUserIntoSessionStorage())
     }
 
-    const attachUserIdAndSavePassword = () => {
-        //Remove any whitespace from the User Name
-        const registrationSearchQuery = helper.removeSpace(registrationForm.userName);
-        let foundUser
+    
+
+    const placeNewUserIntoSessionStorage = () => {
+            const registrationSearchQuery = helper.removeSpace(registrationForm.userName);
+            let foundUser
             //Query the Database to get the newly saved users id/
             API.loginQuery(registrationSearchQuery, "userName")
             .then((response) => {
-                foundUser = response[0];       
-                    //Make the password object to send to the database//
-                    let passwordObject = {
-                        userId: foundUser.id,
-                        password: registrationForm.password
-                    }
-                    //Store the user's password in a seperate database file//
-                    API.addNew( passwordObject, "passwords" )
-                    .then(() => placeNewUserIntoSessionStorage(foundUser))
-                })
-            }
-    }
+                foundUser = response[0]; 
 
-    const placeNewUserIntoSessionStorage = (foundUser) => {
-            delete foundUser.passwords;
+            delete foundUser.password;
             //Set the new users credentials to session storage//
             sessionStorage.setItem("credentials", JSON.stringify(foundUser));
             props.history.push("/dashboard");
-            }
-  
+            })
+        }
             
     
 

--- a/handpickt/src/components/Registration/Registration.js
+++ b/handpickt/src/components/Registration/Registration.js
@@ -118,6 +118,7 @@ const Registration = (props) => {
         let newUserObject = {
             userName: registrationForm.userName,
             email: registrationForm.email,
+            password: registrationForm.password,
             image: registrationForm.image
         }
        API.addNew( newUserObject, "users" )

--- a/handpickt/src/components/Server/HandPicktAPI.js
+++ b/handpickt/src/components/Server/HandPicktAPI.js
@@ -3,7 +3,7 @@ const routeURL = "http://localhost:5002"
 export default {
 
     loginQuery(value, searchType) {
-    return fetch(`${routeURL}/users?${searchType}=${value}&_embed=passwords`)
+    return fetch(`${routeURL}/users?${searchType}=${value}`)
     .then((response) => response.json())
     },
 


### PR DESCRIPTION
# Description
Removal of the "create two simultaneous objects" experiment I was doing with the passwords. Returned to true ERD.

## Type of change

Passwords are once again being saved into the "users" field in the database

# Testing Instructions for REGISTRATION
The user may register a new account from the '/register' route. Account name and email address must be unique to register. Pre-existing values will reject. Password fields must match. Unique warnings will be displayed if any of the following occur:

  1) Account name is left blank
  2) Email is left blank
  3) Password and confirm password do not match
  4) Account name is already in use
  5) Email is already in use

Button to Show/Hide password entry
Link to Login page

If all fields are valid,
Register button will save the Account to the database.
The User object is then acquired from the database with the assigned user id.
User is then placed into session storage (sans password) and directed to '/dashboard'

# Testing Instructions for LOGIN
The user may login from the '/login' route. Account name and password must match what is stored in the database. Unique warnings will be displayed if any of the following occur:

  1) Account name is left blank
  2) Account name is not found
  3) Password  is left blank
  4) Password  does not match stored value

Button to Show/Hide password entry
Link to Registration page

If all fields are valid,
Login button will place user into session storage (sans password) and user is directed to '/dashboard'


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works